### PR TITLE
chore: use slices package where possible 

### DIFF
--- a/api_eip7594.go
+++ b/api_eip7594.go
@@ -2,6 +2,7 @@ package goethkzg
 
 import (
 	"errors"
+	"slices"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-eth-kzg/internal/kzg"
@@ -98,7 +99,7 @@ func (ctx *Context) RecoverCellsAndComputeKZGProofs(cellIDs []uint64, cells []*C
 	// So that they are in normal order
 	missingCellIds := make([]uint64, 0, CellsPerExtBlob)
 	for cellID := uint64(0); cellID < CellsPerExtBlob; cellID++ {
-		if !containsUint64(cellIDs, cellID) {
+		if !slices.Contains(cellIDs, cellID) {
 			missingCellIds = append(missingCellIds, (kzg.BitReverseInt(cellID, CellsPerExtBlob)))
 		}
 	}
@@ -209,17 +210,8 @@ func partition(slice []fr.Element, k int) [][]fr.Element {
 	return result
 }
 
-// TODO: in go 1.21, we can use slice.Contains and remove this method
-func containsUint64(u64Slice []uint64, element uint64) bool {
-	for _, v := range u64Slice {
-		if v == element {
-			return true
-		}
-	}
-
-	return false
-}
-
+// isUniqueUint64 returns true if all elements
+// in the slice are unique
 func isUniqueUint64(slice []uint64) bool {
 	elementMap := make(map[uint64]bool)
 

--- a/internal/kzg_multi/poly.go
+++ b/internal/kzg_multi/poly.go
@@ -1,6 +1,10 @@
 package kzgmulti
 
-import "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+import (
+	"slices"
+
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+)
 
 type PolynomialCoeff = []fr.Element
 
@@ -118,8 +122,7 @@ func PolyEval(poly PolynomialCoeff, inputPoint fr.Element) fr.Element {
 // This was copied and modified from the gnark codebase.
 func DividePolyByXminusA(poly PolynomialCoeff, a fr.Element) []fr.Element {
 	// clone the slice so we do not modify the slice in place
-	// TODO: use slices.Clone
-	quotient := cloneSlice(poly)
+	quotient := slices.Clone(poly)
 
 	var t fr.Element
 
@@ -131,18 +134,6 @@ func DividePolyByXminusA(poly PolynomialCoeff, a fr.Element) []fr.Element {
 
 	// the result is of degree deg(f)-1
 	return quotient[1:]
-}
-
-// cloneSlice creates a copy of the original slice
-//
-// It is up to the user to handle the case of a nil slice.
-func cloneSlice(original []fr.Element) []fr.Element {
-	if original == nil {
-		return nil
-	}
-	cloned := make([]fr.Element, len(original))
-	copy(cloned, original)
-	return cloned
 }
 
 func numCoeffs(p PolynomialCoeff) uint64 {


### PR DESCRIPTION
We have switched to go 1.21, so we can use the slices package where possible to replace common functionality related to slices