### PR TITLE
chore: Remove LagrangeInterpolate function

### DIFF
--- a/internal/poly/poly.go
+++ b/internal/poly/poly.go
@@ -58,11 +58,11 @@ func PolyMul(a, b PolynomialCoeff) PolynomialCoeff {
 	return result
 }
 
-// LagrangeInterpolate computes the polynomial in coefficient form that passes through the given points.
+// lagrangeInterpolate computes the polynomial in coefficient form that passes through the given points.
 // It takes two slices of equal length: xVec (x-coordinates) and yVec (y-coordinates).
 //
 // Note: This will only be used in tests.
-func LagrangeInterpolate(xVec, yVec []fr.Element) PolynomialCoeff {
+func lagrangeInterpolate(xVec, yVec []fr.Element) PolynomialCoeff {
 	n := len(xVec)
 	if n != len(yVec) {
 		panic("Input vectors must have the same length")

--- a/internal/poly/poly_test.go
+++ b/internal/poly/poly_test.go
@@ -29,7 +29,7 @@ func TestPolyMul(t *testing.T) {
 func TestPolyInterpolate(t *testing.T) {
 	points := []fr.Element{fr.NewElement(1), fr.NewElement(2), fr.NewElement(3), fr.NewElement(4)}
 	values := []fr.Element{fr.NewElement(1), fr.NewElement(2), fr.NewElement(3), fr.NewElement(4)}
-	poly := LagrangeInterpolate(points, values)
+	poly := lagrangeInterpolate(points, values)
 	for i, point := range points {
 		eval := PolyEval(poly, point)
 		if !eval.Equal(&values[i]) {


### PR DESCRIPTION
This was pulled out from #85 -- we no longer need lagrangeInterpolate.