### PR TITLE
fix: Replace Fiat-Shamir with random number generation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           git diff-index --quiet HEAD
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
       - name: Run staticcheck
         run: staticcheck ./...
 

--- a/internal/kzg_multi/kzg_verify.go
+++ b/internal/kzg_multi/kzg_verify.go
@@ -1,9 +1,6 @@
 package kzgmulti
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
-
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-eth-kzg/internal/domain"
@@ -13,18 +10,21 @@ import (
 	"github.com/crate-crypto/go-eth-kzg/internal/utils"
 )
 
-// u64ToByteArray16 converts a uint64 to a byte slice of length 16 in big endian format. This implies that the first 8 bytes of the result are always 0.
-func u64ToByteArray16(number uint64) []byte {
-	bytes := make([]byte, 16)
-	binary.BigEndian.PutUint64(bytes[8:], number)
-	return bytes
-}
-
 // Verifies Multiple KZGProofs
 //
 // Note: `cosetEvals` is mutated in-place, ie it should be treated as a mutable reference
 func VerifyMultiPointKZGProofBatch(deduplicatedCommitments []bls12381.G1Affine, commitmentIndices, cosetIndices []uint64, proofs []bls12381.G1Affine, cosetEvals [][]fr.Element, openKey *OpeningKey) error {
-	r := fiatShamirChallenge(deduplicatedCommitments, cosetEvals, commitmentIndices, cosetIndices, openKey)
+	// Sample random numbers for sampling.
+	//
+	// We only need to sample one random number and
+	// compute powers of that random number. This works
+	// since powers will produce a vandermonde matrix
+	// which is linearly independent.
+	var r fr.Element
+	_, err := r.SetRandom()
+	if err != nil {
+		return err
+	}
 	rPowers := utils.ComputePowers(r, uint(len(commitmentIndices)))
 
 	numCosets := len(cosetIndices)
@@ -101,40 +101,4 @@ func VerifyMultiPointKZGProofBatch(deduplicatedCommitments []bls12381.G1Affine, 
 		return kzg.ErrVerifyOpeningProof
 	}
 	return nil
-}
-
-func fiatShamirChallenge(rowCommitments []bls12381.G1Affine, cosetsEvals [][]fr.Element, rowIndices, cosetIndices []uint64, openKey *OpeningKey) fr.Element {
-	const DomSepProtocol = "RCKZGCBATCH__V1_"
-
-	h := sha256.New()
-	h.Write([]byte(DomSepProtocol))
-	h.Write(u64ToByteArray16(openKey.PolySize))
-	h.Write(u64ToByteArray16(openKey.CosetSize))
-
-	lenRowCommitments := len(rowCommitments)
-	h.Write(u64ToByteArray16(uint64(lenRowCommitments)))
-
-	lenCosetIndices := len(cosetIndices)
-	h.Write(u64ToByteArray16(uint64(lenCosetIndices)))
-
-	for _, commitment := range rowCommitments {
-		h.Write(commitment.Marshal())
-	}
-
-	for k := 0; k < lenCosetIndices; k++ {
-		rowIndex := rowIndices[k]
-		cosetIndex := cosetIndices[k]
-		cosetEvals := cosetsEvals[k]
-
-		h.Write(u64ToByteArray16(rowIndex))
-		h.Write(u64ToByteArray16(cosetIndex))
-		for _, eval := range cosetEvals {
-			h.Write(eval.Marshal())
-		}
-	}
-
-	digest := h.Sum(nil)
-	var challenge fr.Element
-	challenge.SetBytes(digest[:])
-	return challenge
 }


### PR DESCRIPTION
zkSecurity found a bug in the current code where the proof was not included.

This fixes it while also aligning the behaviour with the 4844 implementation