### PR TITLE
chore: Make Pivot point zero

### DIFF
--- a/internal/kzg_multi/fk20/toeplitz.go
+++ b/internal/kzg_multi/fk20/toeplitz.go
@@ -22,7 +22,7 @@ func (tm *toeplitzMatrix) embedCirculant() circulantMatrix {
 	copy(row, tm.col)
 
 	// Append rotated and reversed tm.Row
-	for i := 0; i < n; i++ {
+	for i := 1; i < n; i++ {
 		row[len(tm.col)+i] = tm.row[(n-i)%n]
 	}
 	return circulantMatrix{row: row}


### PR DESCRIPTION
This came from the zk security audit: The pivot point is a "free-standing" variable so it can be any value, we set it to zero to be consistent with the paper.