### PR TITLE
Add RecoverCells method

### DIFF
--- a/api_eip.go
+++ b/api_eip.go
@@ -11,24 +11,9 @@ func (ctx *Context) RecoverCells(cellIDs []uint64, cells []*Cell) ([CellsPerExtB
 	if len(cellIDs) != len(cells) {
 		return [CellsPerExtBlob]*Cell{}, ErrNumCellIDsNotEqualNumCells
 	}
-
-	// Check that the cell Ids are ordered (ascending)
-	if !isAscending(cellIDs) {
-		return [CellsPerExtBlob]*Cell{}, ErrCellIDsNotOrdered
+	if err := ctx.verifyCellIndices(cellIDs); err != nil {
+		return [CellsPerExtBlob]*Cell{}, err
 	}
-
-	// Check that each CellId is less than CellsPerExtBlob
-	for _, cellID := range cellIDs {
-		if cellID >= CellsPerExtBlob {
-			return [CellsPerExtBlob]*Cell{}, ErrFoundInvalidCellID
-		}
-	}
-
-	// Check that we have enough cells to perform reconstruction
-	if len(cellIDs) < ctx.dataRecovery.NumBlocksNeededToReconstruct() {
-		return [CellsPerExtBlob]*Cell{}, ErrNotEnoughCellsForReconstruction
-	}
-
 	// Find the missing cell IDs and bit reverse them
 	// So that they are in normal order
 	missingCellIds := make([]uint64, 0, CellsPerExtBlob)

--- a/api_eip.go
+++ b/api_eip.go
@@ -1,0 +1,65 @@
+package goethkzg
+
+import (
+	"slices"
+
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/crate-crypto/go-eth-kzg/internal/domain"
+)
+
+func (ctx *Context) RecoverCells(cellIDs []uint64, cells []*Cell) ([CellsPerExtBlob]*Cell, error) {
+	if len(cellIDs) != len(cells) {
+		return [CellsPerExtBlob]*Cell{}, ErrNumCellIDsNotEqualNumCells
+	}
+
+	// Check that the cell Ids are ordered (ascending)
+	if !isAscending(cellIDs) {
+		return [CellsPerExtBlob]*Cell{}, ErrCellIDsNotOrdered
+	}
+
+	// Check that each CellId is less than CellsPerExtBlob
+	for _, cellID := range cellIDs {
+		if cellID >= CellsPerExtBlob {
+			return [CellsPerExtBlob]*Cell{}, ErrFoundInvalidCellID
+		}
+	}
+
+	// Check that we have enough cells to perform reconstruction
+	if len(cellIDs) < ctx.dataRecovery.NumBlocksNeededToReconstruct() {
+		return [CellsPerExtBlob]*Cell{}, ErrNotEnoughCellsForReconstruction
+	}
+
+	// Find the missing cell IDs and bit reverse them
+	// So that they are in normal order
+	missingCellIds := make([]uint64, 0, CellsPerExtBlob)
+	for cellID := uint64(0); cellID < CellsPerExtBlob; cellID++ {
+		if !slices.Contains(cellIDs, cellID) {
+			missingCellIds = append(missingCellIds, (domain.BitReverseInt(cellID, CellsPerExtBlob)))
+		}
+	}
+
+	// Convert Cells to field elements
+	extendedBlob := make([]fr.Element, scalarsPerExtBlob)
+	// for each cellId, we get the corresponding cell in cells
+	// then use the cellId to place the cell in the correct position in the data(extendedBlob) array
+	for i, cellID := range cellIDs {
+		cell := cells[i]
+		// Deserialize the cell
+		cellEvals, err := deserializeCell(cell)
+		if err != nil {
+			return [CellsPerExtBlob]*Cell{}, err
+		}
+		// Place the cell in the correct position in the data array
+		copy(extendedBlob[cellID*scalarsPerCell:], cellEvals)
+	}
+	// Bit reverse the extendedBlob so that it is in normal order
+	domain.BitReverse(extendedBlob)
+
+	polyCoeff, err := ctx.dataRecovery.RecoverPolynomialCoefficients(extendedBlob, missingCellIds)
+	if err != nil {
+		return [CellsPerExtBlob]*Cell{}, err
+	}
+
+	evals := ctx.fk20.ComputeExtendedPolynomial(polyCoeff)
+	return serializeCells(evals)
+}


### PR DESCRIPTION
This PR implements the `RecoverCells` method, which recovers cells without computing proofs.

This is needed in cases where the client receives proofs through a side channel (e.g., over the network) and only needs to recover the cells. When introducing cell-level blobpool in EL, EL may want to receive proofs from its peers before the cells are exchanged.

The `RecoverCells` method shares almost the same logic as the `RecoverCellsAndComputeKZGProofs` method. I am open to any refactoring suggestions regarding this.

I also created a new file `api_eip.go`, as it seems appropriate to rename the file once proposals related to this (e.g., sparse blobpool, unconditional payment) are shipped.